### PR TITLE
Boj guide/2193

### DIFF
--- a/BojGuide/2193.cpp
+++ b/BojGuide/2193.cpp
@@ -1,0 +1,25 @@
+#include <iostream>
+#include <cstring>
+using namespace std;
+
+int N;
+int dp[2][90];
+
+int dfs(int num, int depth) {
+	if(depth == N-1)
+		return 1;
+	int ret = dp[num][depth];
+	if(ret != -1)
+		return ret;
+	ret = 0;
+	ret += dfs(0, depth+1);
+	if(num != 1)
+		ret += dfs(1, depth+1);
+	return ret;
+}
+
+int main() {
+	memset(dp, -1, sizeof(dp));
+	cin >> N;	
+	cout << dfs(1, 0);
+}

--- a/BojGuide/2193.cpp
+++ b/BojGuide/2193.cpp
@@ -3,12 +3,12 @@
 using namespace std;
 
 int N;
-int dp[2][90];
+long long dp[2][90];
 
-int dfs(int num, int depth) {
+long long dfs(int num, int depth) {
 	if(depth == N-1)
 		return 1;
-	int ret = dp[num][depth];
+	long long &ret = dp[num][depth];
 	if(ret != -1)
 		return ret;
 	ret = 0;


### PR DESCRIPTION
### **Issue number**

- [x] #27 

#### Timeout
- 1702208dc4efd9599e59cd077955044cf9e1c315  was just caused by a mistake. I forgot to add reference mark to ret.

#### Solve
- 8fa196a7544183c753d377081f75690a97f363e2

1.  Resolve timeout by making value 'ret' to reference type.
2. Convert return type of dfs int to long long. Because it's number of cases is expeceted about (1.5)^90.
